### PR TITLE
fixup! Fall back to photo ID if available when obs id is invalid

### DIFF
--- a/src/inrbot.py
+++ b/src/inrbot.py
@@ -981,6 +981,8 @@ class CommonsPage:
                     # If we've got a photo ID, try that.
                     del self.obs_id
                     self.find_photo_in_obs()
+                else:
+                    raise
             self.compare_licenses()
             self.get_ina_author()
             self.archive


### PR DESCRIPTION
Ensure error is reraised if it can't be handled.