### PR TITLE
Remove {{iNaturalistReview}} check from check_can_run

### DIFF
--- a/src/inrbot.py
+++ b/src/inrbot.py
@@ -44,7 +44,7 @@ from typing import Any, Iterator
 
 import acnutils
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"
 
 logger = acnutils.getInitLogger("inrbot", level="VERBOSE", filename="inrbot.log")
 
@@ -475,7 +475,7 @@ class CommonsPage:
             return True
 
     def check_has_template(self) -> bool:
-        return bool(re.search(r"{{[iI][nN]aturalist[rR]eview}}", self.page.text))
+        return bool(re.search(r"{{[iI][nN]aturalist[rR]eview", self.page.text))
 
     def check_stop_cats(self) -> None:
         stop_cats = {

--- a/src/inrcli.py
+++ b/src/inrcli.py
@@ -81,6 +81,18 @@ class ManualCommonsPage(inrbot.CommonsPage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    def check_can_run(self) -> bool:
+        """Determinies if the bot should run on this page and returns a bool."""
+        page = self.page
+        if (
+            (page.title() in inrbot.skip)
+            or (not page.has_permission("edit"))
+            or (not page.botMayEdit())
+        ):
+            return False
+        else:
+            return True
+
     def get_old_archive_(self):
         return super().get_old_archive()
 
@@ -209,7 +221,8 @@ def main(target, url="", simulate=False, reverse=False):
             if dtt in set(page.itertemplates()):
                 continue
             try:
-                ManualCommonsPage(pywikibot.FilePage(page)).review_file()
+                mcp = ManualCommonsPage(pywikibot.FilePage(page))
+                mcp.review_file()
             except SkipFile:
                 continue
     elif target == "errors":


### PR DESCRIPTION
check_can_run used to check that files were tagged with {{iNaturalistReview}}. When the bot was updated to check untagged files, the logic in check_can_run was changed to exclude pages that have already been reviewed. That broke inrcli for previously tagged files.

Also fix check_has_template to include reviewed files