### PR TITLE
Skip redundant check for any license

### DIFF
--- a/src/inrbot.py
+++ b/src/inrbot.py
@@ -706,15 +706,10 @@ class CommonsPage:
         templates = set(self.page.itertemplates())
         license_tags = set(category.members(namespaces=10))
 
-        if pywikibot.Page(site, "Template:License template tag") in templates:
-            for template in templates:
-                if template in license_tags:
-                    self._com_license = template.title(with_ns=False)
-                    break
-            else:
-                raise ProcessingError(
-                    "comlicense", "Could not determine Commons license"
-                )
+        for template in templates:
+            if template in license_tags:
+                self._com_license = template.title(with_ns=False)
+                break
         else:
             logger.info("No Commons license found!")
             self._com_license = ""

--- a/tests/test_inrbot.py
+++ b/tests/test_inrbot.py
@@ -423,14 +423,6 @@ def test_com_license_none():
     assert cpage.com_license == ""
 
 
-def test_com_license_unk():
-    site = pywikibot.Site("commons", "commons")
-    page = pywikibot.Page(site, "Template:CC-Layout")
-    cpage = inrbot.CommonsPage(page)
-    with pytest.raises(inrbot.ProcessingError, match="comlicense"):
-        cpage.get_com_license()
-
-
 @pytest.mark.parametrize(
     "ina_license,com_license,expected",
     [
@@ -519,12 +511,12 @@ def test_is_old(status, timestamp, expected):
         (
             "fail",
             [
-                pywikibot.Page(inrbot.site, "Template:License template tag"),
+                pywikibot.Page(inrbot.site, "Template:Cc-by-sa-4.0"),
                 pywikibot.Page(inrbot.site, "Template:OTRS received"),
             ],
             True,
         ),
-        ("fail", [pywikibot.Page(inrbot.site, "Template:License template tag")], False),
+        ("fail", [pywikibot.Page(inrbot.site, "Template:Cc-by-sa-4.0")], False),
         ("pass", [pywikibot.Page(inrbot.site, "Template:OTRS received")], False),
     ],
 )


### PR DESCRIPTION
Checking for {{License template tag}} has always been redundant and will not work in the future. Checking for templates by category should be sufficient.

Bug: T343131