### PR TITLE
Never save page on status=stop

### DIFF
--- a/src/inrbot.py
+++ b/src/inrbot.py
@@ -32,7 +32,7 @@ from typing import Any, Iterator
 
 import acnutils
 
-__version__ = "2.6.1"
+__version__ = "2.7.0"
 
 logger = acnutils.getInitLogger("inrbot", level="VERBOSE", filename="inrbot.log")
 
@@ -1238,6 +1238,7 @@ class CommonsPage:
         except StopReview as err:
             logger.info(f"Image already reviewed, contains {err.reason}")
             self.status = "stop"
+            return False
         except (acnutils.RunpageError, KeyboardInterrupt, ConnectionError) as err:
             raise err
         except Exception as err:

--- a/tests/test_inrbot.py
+++ b/tests/test_inrbot.py
@@ -1131,7 +1131,7 @@ def test_review_file_stop(runpage):
     ):
         cpage.review_file()
     assert cpage.status == "stop"
-    mock_review.assert_called_once()
+    mock_review.assert_not_called()
     runpage.assert_called()
 
 


### PR DESCRIPTION
I think my intent was to remove redundant {{iNaturalistreview}} templates. But that doesn't work and it can, in certain (TOCTOU) situations, cause existing {{LicenseReview}} templates to be removed.

Tag cleanup could be re-implemented more carefully in the future.